### PR TITLE
Constant pragma special case

### DIFF
--- a/lib/PPIx/Utils/Traversal.pm
+++ b/lib/PPIx/Utils/Traversal.pm
@@ -193,6 +193,11 @@ sub _get_constant_names_from_constant_pragma {
     my $follower = $arguments[0];
     return() if not defined $follower;
 
+    if ($follower->isa('PPI::Token::Operator') && $follower->content eq '+') {
+        $follower = $arguments[1];
+        return() if not defined $follower;
+    }
+
     # We test for a 'PPI::Structure::Block' in the following because some
     # versions of PPI parse the last element of 'use constant { ONE => 1, TWO
     # => 2 }' as a block rather than a constructor. As of PPI 1.206, PPI

--- a/t/utils_traversal.t
+++ b/t/utils_traversal.t
@@ -66,6 +66,7 @@ sub test_get_constant_name_elements_from_declaring_statement {
         ['use constant FOO => 1;', ['FOO']],
         ['use constant { FOO => 1 };', ['FOO']],
         ['use constant { FOO => 1, BAR => 2 };', ['FOO', 'BAR']],
+        ['use constant +{ FOO => 1, BAR => 2 };', ['FOO', 'BAR']],
     );
 
     foreach my $test (@tests) {

--- a/t/utils_traversal.t
+++ b/t/utils_traversal.t
@@ -9,6 +9,7 @@ use Test::More;
 
 test_first_arg();
 test_parse_arg_list();
+test_get_constant_name_elements_from_declaring_statement();
 
 sub test_first_arg {
     my @tests = (
@@ -57,6 +58,24 @@ sub test_parse_arg_list {
         is_deeply( \@got, $expected, "parse_arg_list: $code" );
     }
 
+    return;
+}
+
+sub test_get_constant_name_elements_from_declaring_statement {
+    my @tests = (
+        ['use constant FOO => 1;', ['FOO']],
+        ['use constant { FOO => 1 };', ['FOO']],
+        ['use constant { FOO => 1, BAR => 2 };', ['FOO', 'BAR']],
+    );
+
+    foreach my $test (@tests) {
+        my ($code, $expected) = @{ $test };
+
+        my $document = PPI::Document->new( \$code );
+        my $st = $document->find_first('PPI::Statement::Include');
+        my @got = get_constant_name_elements_from_declaring_statement( $st );
+        is_deeply( \@got, $expected, "get_constant_name_elements_from_declaring_statement: $code" );
+    }
     return;
 }
 


### PR DESCRIPTION
I've add a few test cases for the method `get_constant_name_elements_from_declaring_statement`, as well as improving it for this particular special case:

    use constant +{ FOO => 1, BAR => 2 };

Without this PR, that statement makes the method return only the plus token (`+`).

See commit 48a287c.
